### PR TITLE
Merge tag 'android-6.0.1_r61' into HEAD

### DIFF
--- a/core/build_id.mk
+++ b/core/build_id.mk
@@ -18,4 +18,4 @@
 # (like "CRB01").  It must be a single word, and is
 # capitalized by convention.
 
-export BUILD_ID=MOB30R
+export BUILD_ID=MOB30Z

--- a/core/main.mk
+++ b/core/main.mk
@@ -326,6 +326,7 @@ tags_to_install :=
 ifneq (,$(user_variant))
   # Target is secure in user builds.
   ADDITIONAL_DEFAULT_PROPERTIES += ro.secure=1
+  ADDITIONAL_DEFAULT_PROPERTIES += security.perf_harden=1
 
   ifeq ($(user_variant),userdebug)
     # Pick up some extra useful tools

--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -103,7 +103,7 @@ ifeq "" "$(PLATFORM_SECURITY_PATCH)"
   # Can be an arbitrary string, but must be a single word.
   #
   # If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-  PLATFORM_SECURITY_PATCH := 2016-07-05
+  PLATFORM_SECURITY_PATCH := 2016-08-05
 endif
 
 ifeq "" "$(PLATFORM_BASE_OS)"


### PR DESCRIPTION
Android 6.0.1 Release 61 (MOB30Z)

Change-Id: Ie36ef38fa4add95de1053c7fa5dd94bed9f94607
Reviewed-on: http://review.blissroms.com/3770
Reviewed-by: Patrick Graber
Tested-by: Patrick Graber
